### PR TITLE
Add comprehensive unit tests for lambda utilities and handler

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,0 +1,50 @@
+from lambda_function import handler, util
+
+
+class DummyContext:
+    def get_remaining_time_in_millis(self):
+        return 100000
+
+
+class DummyLaneMux:
+    instances = []
+
+    def __init__(self, lane_count, max_workers, worker_factory):
+        self.submitted = []
+        DummyLaneMux.instances.append(self)
+
+    def submit(self, lane_id, item):
+        self.submitted.append((lane_id, item))
+
+    def drain_and_close(self, deadline_epoch):
+        return len(self.submitted), 0
+
+    def force_close(self):
+        pass
+
+
+def test_lambda_handler_template_clone(monkeypatch):
+    DummyLaneMux.instances = []
+    monkeypatch.setattr(handler, "LaneMux", DummyLaneMux)
+    event = {
+        "mode": "TEMPLATE_CLONE",
+        "job_id": "JOB-1234",
+        "http": {"base_url": "http://example.com"},
+        "publish": {"lane_count": 2},
+        "template_clone": {
+            "count": 2,
+            "event_name": "SampleEvent",
+            "template_inline": {},
+        },
+    }
+    result = handler.lambda_handler(event, DummyContext())
+    assert result["processed"] == 2
+    instance = DummyLaneMux.instances[0]
+    assert len(instance.submitted) == 2
+    loans = [item[1]["loan"] for item in instance.submitted]
+    expected = [
+        util.generate_loan_number("", i, "JOB-1234") for i in range(2)
+    ]
+    assert loans == expected
+    for _, item in instance.submitted:
+        assert item["attributes"]["eventName"] == "SampleEvent"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,49 @@
+import pytest
+
+from lambda_function.util import (
+    normalize_loan_10,
+    generate_loan_number,
+    derive_event_name,
+    extract_loan,
+)
+from lambda_function.template import render_with_loan
+
+
+def test_normalize_loan_10():
+    assert normalize_loan_10("12-34") == "0000001234"
+    with pytest.raises(ValueError):
+        normalize_loan_10("")
+
+
+def test_generate_loan_number_deterministic():
+    loan1 = generate_loan_number("12", 1, "job")
+    loan2 = generate_loan_number("12", 1, "job")
+    assert loan1 == loan2
+    assert loan1.startswith("12")
+    assert len(loan1) == 10
+
+
+def test_derive_event_name_and_extract_loan():
+    record = {"loan_no": "123"}
+    assert extract_loan(record) == "0000000123"
+    with pytest.raises(ValueError):
+        extract_loan({})
+    assert (
+        derive_event_name(
+            "loan_file.json",
+            None,
+            None,
+        )
+        == "LoanOnboardCompleted"
+    )
+    assert derive_event_name(None, "Explicit", {}) == "Explicit"
+    assert (
+        derive_event_name(None, None, {"eventName": "Foo"}) == "Foo"
+    )
+
+
+def test_render_with_loan():
+    template = {"loan": "#loanNumberPlaceholder", "seq": "{seq}"}
+    rendered = render_with_loan(template, "12345", 7)
+    assert rendered["loan"] == "12345"
+    assert rendered["seq"] == "7"


### PR DESCRIPTION
## Summary
- add tests for loan utilities including normalization, generation, event name derivation, and template rendering
- cover TEMPLATE_CLONE path in lambda handler using a dummy lane mux

## Testing
- `flake8 tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c94ecba79c832985b70db4cb4dd381