### PR TITLE
Normalize HTTP publisher path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A single AWS Lambda (Python 3.12) that:
 
 **Publishers**
 - **Primary:** `submitter_http` → POST to `/sendMessage` with max parallelism.
+  - The `http.path` value accepts either `"sendMessage"` or `"/sendMessage"` (leading slash optional).
 - **Secondary (optional):** `sns` → publish to SNS FIFO (boto3).
 
 **Ordering (strict per-loan)**
@@ -32,7 +33,7 @@ A single AWS Lambda (Python 3.12) that:
   "job_id": "JOB-2025-09-12-001",
   "mode": "TEMPLATE_CLONE",
   "backend": "submitter_http",
-  "http": { "base_url": "https://internal/service", "path": "/sendMessage", "max_pool": 256, "timeout_s": 3 },
+  "http": { "base_url": "https://internal/service", "path": "sendMessage", "max_pool": 256, "timeout_s": 3 },
   "publish": { "lane_count": 64, "max_workers": 64, "time_budget_secs": 840 },
   "grouping": { "loan_field": "loanNumber", "strict_fifo_per_loan": true },
   "template_clone": {

--- a/lambda_function/publisher_http.py
+++ b/lambda_function/publisher_http.py
@@ -11,7 +11,12 @@ class SubmitterHttpPublisher:
     """
 
     def __init__(self, base_url: str, path: str = "/sendMessage", max_pool: int = 256, timeout_s: float = 3.0):
-        self.url = base_url.rstrip("/") + path
+        normalized_base = base_url.rstrip("/")
+        normalized_path = path.lstrip("/") if path else ""
+        if normalized_path:
+            self.url = f"{normalized_base}/{normalized_path}"
+        else:
+            self.url = normalized_base
         self.pool = urllib3.PoolManager(
             num_pools=max_pool, maxsize=max_pool, timeout=urllib3.Timeout(total=timeout_s, connect=1.0, read=timeout_s), retries=False
         )

--- a/lambda_function/publisher_http.py
+++ b/lambda_function/publisher_http.py
@@ -12,7 +12,7 @@ class SubmitterHttpPublisher:
 
     def __init__(self, base_url: str, path: str = "/sendMessage", max_pool: int = 256, timeout_s: float = 3.0):
         normalized_base = base_url.rstrip("/")
-        normalized_path = path.lstrip("/") if path else ""
+        normalized_path = path.lstrip("/") if path is not None else ""
         if normalized_path:
             self.url = f"{normalized_base}/{normalized_path}"
         else:

--- a/test_events.json
+++ b/test_events.json
@@ -5,7 +5,7 @@
     "backend": "submitter_http",
     "http": {
       "base_url": "https://internal.example.com/service",
-      "path": "/sendMessage",
+      "path": "sendMessage",
       "max_pool": 256,
       "timeout_s": 3
     },

--- a/tests/test_publisher_http.py
+++ b/tests/test_publisher_http.py
@@ -1,0 +1,46 @@
+"""Tests for the Submitter HTTP publisher configuration."""
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+dummy_urllib3 = types.ModuleType("urllib3")
+
+
+class _DummyPoolManager:  # pragma: no cover - simple stub
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class _DummyTimeout:  # pragma: no cover - simple stub
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+dummy_urllib3.PoolManager = _DummyPoolManager
+dummy_urllib3.Timeout = _DummyTimeout
+sys.modules.setdefault("urllib3", dummy_urllib3)
+
+from lambda_function.publisher_http import SubmitterHttpPublisher  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "base_url,path,expected",
+    [
+        ("https://internal.example.com/service", "sendMessage", "https://internal.example.com/service/sendMessage"),
+        ("https://internal.example.com/service", "/sendMessage", "https://internal.example.com/service/sendMessage"),
+        ("https://internal.example.com/service/", "sendMessage", "https://internal.example.com/service/sendMessage"),
+        ("https://internal.example.com/service/", "/sendMessage", "https://internal.example.com/service/sendMessage"),
+    ],
+)
+def test_submitter_http_publisher_normalizes_path_variants(base_url, path, expected):
+    publisher = SubmitterHttpPublisher(base_url, path)
+
+    assert publisher.url == expected
+    assert publisher.url.endswith("/sendMessage")


### PR DESCRIPTION
## Summary
- normalize the HTTP publisher URL assembly so path values with or without a leading slash resolve to the same endpoint
- add regression coverage for SubmitterHttpPublisher path normalization and clarify docs/sample events about accepted path formats

## Testing
- ruff check lambda_function/publisher_http.py tests/test_publisher_http.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9c7839f4c8329b1eadf3d63380a90